### PR TITLE
Add guided classroom mode and accuracy metrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,12 @@ limitations under the License.
           <i class="material-icons">skip_next</i>
         </button>
       </div>
+      <div class="guided-controls ui-guided" style="display:flex;gap:8px;align-items:center">
+        <button id="guided-prev" class="mdl-button mdl-js-button mdl-button--icon"><i class="material-icons">chevron_left</i></button>
+        <span id="guided-level">Niveau 1/5</span>
+        <button id="guided-next" class="mdl-button mdl-js-button mdl-button--icon"><i class="material-icons">chevron_right</i></button>
+        <button id="guided-toggle" class="mdl-button mdl-js-button">Mode libre</button>
+      </div>
       <div class="control">
         <span class="label">Époque</span>
         <span class="value" id="iter-number"></span>
@@ -82,22 +88,22 @@ limitations under the License.
       <div class="ui-dataset">
         
         <div class="dataset-list">
-          <div class="dataset" title="Circle">
+          <div class="dataset" title="Cercle">
             <canvas class="data-thumbnail" data-dataset="circle"></canvas>
           </div>
-          <div class="dataset" title="Exclusive or">
+          <div class="dataset" title="Ou exclusif">
             <canvas class="data-thumbnail" data-dataset="xor"></canvas>
           </div>
-          <div class="dataset" title="Gaussian">
+          <div class="dataset" title="Gaussienne">
             <canvas class="data-thumbnail" data-dataset="gauss"></canvas>
           </div>
-          <div class="dataset" title="Spiral">
+          <div class="dataset" title="Spirale">
             <canvas class="data-thumbnail" data-dataset="spiral"></canvas>
           </div>
-          <div class="dataset" title="Plane">
+          <div class="dataset" title="Plan">
             <canvas class="data-thumbnail" data-regDataset="reg-plane"></canvas>
           </div>
-          <div class="dataset" title="Multi gaussian">
+          <div class="dataset" title="Gaussienne multiple">
             <canvas class="data-thumbnail" data-regDataset="reg-gauss"></canvas>
           </div>
         </div>
@@ -174,6 +180,8 @@ limitations under the License.
           <span>Perte d'entraînement: </span>
           <div class="value" id="loss-train"></div>
         </div>
+        <div class="output-stats"><span>Exactitude test: </span><div class="value" id="acc-test"></div></div>
+        <div class="output-stats train"><span>Exactitude entraînement: </span><div class="value" id="acc-train"></div></div>
         <div id="linechart"></div>
       </div>
       <div id="heatmap"></div>

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -884,6 +884,28 @@ function updateUI(firstStep = false) {
   lineChart.addDataPoint([lossTrain, lossTest]);
 }
 
+function computeAccuracy(data: Example2D[]): number {
+  let c = 0;
+  for (let i = 0; i < data.length; i++) {
+    const p = data[i];
+    const y = nn.forwardProp(network, constructInput(p.x, p.y));
+    const pred = y >= 0 ? 1 : -1;
+    if (pred === (p.label >= 0 ? 1 : -1)) c++;
+  }
+  return data.length ? c / data.length : 0;
+}
+
+const fmtPct = (v: number) => (100 * v).toFixed(1) + "%";
+
+const _updateUI = updateUI;
+updateUI = function(firstStep = false) {
+  _updateUI(firstStep);
+  const accTrain = computeAccuracy(trainData);
+  const accTest = computeAccuracy(testData);
+  d3.select("#acc-train").text(fmtPct(accTrain));
+  d3.select("#acc-test").text(fmtPct(accTest));
+}
+
 function constructInputIds(): string[] {
   let result: string[] = [];
   for (let inputName in INPUTS) {
@@ -1117,3 +1139,78 @@ makeGUI();
 generateData(true);
 reset(true);
 hideControls();
+
+type LevelSpec = {
+  problem: Problem;
+  datasetKey: keyof typeof datasets;
+  inputs: {x: boolean; y: boolean; xSquared: boolean; ySquared: boolean; xTimesY: boolean;};
+  networkShape: number[];
+  show: string[];
+  allowedDatasets?: string[];
+};
+
+let guidedEnabled = true;
+let levelIndex = 0;
+
+const LEVELS: LevelSpec[] = [
+  {problem: Problem.CLASSIFICATION, datasetKey: "gauss", inputs:{x:true,y:true,xSquared:false,ySquared:false,xTimesY:false}, networkShape:[2], show:["resetButton","stepButton"], allowedDatasets:["gauss"]},
+  {problem: Problem.CLASSIFICATION, datasetKey: "gauss", inputs:{x:true,y:true,xSquared:false,ySquared:false,xTimesY:false}, networkShape:[2], show:["resetButton","playButton"]},
+  {problem: Problem.CLASSIFICATION, datasetKey: "circle", inputs:{x:true,y:true,xSquared:true,ySquared:true,xTimesY:false}, networkShape:[2], show:["resetButton","playButton"]},
+  {problem: Problem.CLASSIFICATION, datasetKey: "xor", inputs:{x:true,y:true,xSquared:true,ySquared:true,xTimesY:true}, networkShape:[4,2], show:["resetButton","playButton","numHiddenLayers","activation"]},
+  {problem: Problem.CLASSIFICATION, datasetKey: "xor", inputs:{x:true,y:true,xSquared:true,ySquared:true,xTimesY:true}, networkShape:[6,4], show:["resetButton","playButton","numHiddenLayers","activation","noise","showTestData"]}
+];
+
+function applyGuidedLevel(i: number) {
+  if (!guidedEnabled) return;
+  levelIndex = Math.max(0, Math.min(LEVELS.length - 1, i));
+  const L = LEVELS[levelIndex];
+  const showSet = new Set(L.show);
+  HIDABLE_CONTROLS.forEach(([_, id]) => {
+    const mustShow = showSet.has(id);
+    state.setHideProperty(id, !mustShow);
+  });
+  state.problem = L.problem;
+  state.dataset = datasets[L.datasetKey];
+  state.x = L.inputs.x;
+  state.y = L.inputs.y;
+  state.xSquared = L.inputs.xSquared;
+  state.ySquared = L.inputs.ySquared;
+  state.xTimesY = L.inputs.xTimesY;
+  state.networkShape = L.networkShape;
+  state.numHiddenLayers = L.networkShape.length - 1;
+  state.serialize();
+  if (L.allowedDatasets && L.allowedDatasets.length) {
+    d3.selectAll(".dataset").style("display", "none");
+    L.allowedDatasets.forEach(k => {
+      d3.select(`canvas[data-dataset=${k}]`).each(function() {
+        d3.select((this as any).parentNode as Element).style("display", null);
+      });
+    });
+  }
+  drawDatasetThumbnails();
+  generateData(true);
+  reset(true);
+  hideControls();
+  d3.select("#guided-level").text(`Niveau ${levelIndex + 1}/${LEVELS.length}`);
+  d3.select("body").classed("guided-locked", true);
+}
+
+function initGuidedUI() {
+  d3.select("#guided-prev").on("click", () => applyGuidedLevel(levelIndex - 1));
+  d3.select("#guided-next").on("click", () => applyGuidedLevel(levelIndex + 1));
+  d3.select("#guided-toggle").on("click", () => {
+    guidedEnabled = !guidedEnabled;
+    if (!guidedEnabled) {
+      HIDABLE_CONTROLS.forEach(([_, id]) => state.setHideProperty(id, false));
+      state.serialize();
+      hideControls();
+      d3.select("#guided-level").text("Mode libre");
+      d3.select("body").classed("guided-locked", false);
+    } else {
+      applyGuidedLevel(levelIndex);
+    }
+  });
+  applyGuidedLevel(0);
+}
+
+initGuidedUI();

--- a/styles.css
+++ b/styles.css
@@ -992,3 +992,10 @@ footer .links a:hover {
 #main-part .mdl-slider.is-upgraded:focus:not(:active)::-webkit-slider-thumb {
   box-shadow: 0 0 0 10px rgba(0,0,0, 0.12);
 }
+
+body.guided-locked #network .core .link-hover {
+  pointer-events: none;
+}
+body.guided-locked #hovercard {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- Add guided classroom navigation controls with predefined levels
- Show accuracy alongside loss and lock weight editing in guided mode
- Localize dataset titles to French

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a0e58922c8331b9cf0a86069bb3a9